### PR TITLE
Refactor utilities and optimize CSV import

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
+import os
+import sys
 import tempfile
 
 import pytest
+
+# Ensure local package is imported before site packages
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 
 @pytest.fixture

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,31 @@
+import importlib
+
+import pandas as pd
+
+import trackio.utils as utils
+
+importlib.reload(utils)
+
+downsample_df = utils.downsample_df
+simplify_column_names = utils.simplify_column_names
+
+
+def test_downsample_df_reduce():
+    df = pd.DataFrame({"x": range(100)})
+    reduced = downsample_df(df, 10)
+    assert len(reduced) == 10
+    assert reduced.iloc[0]["x"] == 0
+    assert reduced.iloc[-1]["x"] == 99
+
+
+def test_downsample_df_no_change():
+    df = pd.DataFrame({"x": range(5)})
+    reduced = downsample_df(df, 10)
+    assert len(reduced) == 5
+
+
+def test_simplify_column_names_unique():
+    cols = ["metric/long_name", "non alpha*"]
+    simplified = simplify_column_names(cols)
+    assert simplified[cols[0]] == "metric/lon"
+    assert simplified[cols[1]] == "nonalpha"

--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -10,6 +10,7 @@ from gradio_client import Client, handle_file
 from httpx import ReadTimeout
 from huggingface_hub.errors import RepositoryNotFoundError
 
+from trackio import utils
 from trackio.sqlite_storage import SQLiteStorage
 
 SPACE_URL = "https://huggingface.co/spaces/{space_id}"
@@ -117,16 +118,13 @@ def wait_until_space_exists(
     Args:
         space_id: The ID of the Space to wait for.
     """
-    client = None
+    fib = utils.fibo()
     for _ in range(30):
         try:
-            client = Client(space_id, verbose=False)
-            if client:
-                break
-        except ReadTimeout:
-            time.sleep(5)
-        except ValueError:
-            time.sleep(5)
+            Client(space_id, verbose=False)
+            return
+        except (ReadTimeout, ValueError):
+            time.sleep(5 * next(fib))
     raise TimeoutError("Waiting for space to exist took longer than expected")
 
 

--- a/trackio/ui.py
+++ b/trackio/ui.py
@@ -10,10 +10,10 @@ HfApi = hf.HfApi()
 
 try:
     from trackio.sqlite_storage import SQLiteStorage
-    from trackio.utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
+    from trackio.utils import RESERVED_KEYS, TRACKIO_LOGO_PATH, downsample_df
 except:  # noqa: E722
     from sqlite_storage import SQLiteStorage
-    from utils import RESERVED_KEYS, TRACKIO_LOGO_PATH
+    from utils import RESERVED_KEYS, TRACKIO_LOGO_PATH, downsample_df
 
 css = """
 #run-cb .wrap {
@@ -476,6 +476,7 @@ with gr.Blocks(theme="citrus", title="Trackio Dashboard", css=css) as demo:
             for metric_idx, metric_name in enumerate(numeric_cols):
                 metric_df = master_df.dropna(subset=[metric_name])
                 if not metric_df.empty:
+                    metric_df = downsample_df(metric_df, 1000)
                     plot = gr.LinePlot(
                         metric_df,
                         x=x_column,


### PR DESCRIPTION
## Summary
- hoist adjective/noun lists and regex into module-level constants
- speed up name generation and column simplification
- improve numeric detection & row iteration for CSV import
- create composite index on project/run/step
- refactor project lookup using set and SQL
- fix wait_until_space_exists retry logic
- add downsample_df and use it in UI plots
- ensure tests import local package and add utils tests

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea0ed3b588328af67692e08a42e78