### PR TITLE
Improve caching and performance

### DIFF
--- a/trackio/deploy.py
+++ b/trackio/deploy.py
@@ -10,7 +10,6 @@ from gradio_client import Client, handle_file
 from httpx import ReadTimeout
 from huggingface_hub.errors import RepositoryNotFoundError
 
-from trackio import utils
 from trackio.sqlite_storage import SQLiteStorage
 
 SPACE_URL = "https://huggingface.co/spaces/{space_id}"
@@ -118,13 +117,14 @@ def wait_until_space_exists(
     Args:
         space_id: The ID of the Space to wait for.
     """
-    fib = utils.fibo()
-    for _ in range(30):
+    delay = 1
+    for _ in range(10):
         try:
             Client(space_id, verbose=False)
             return
         except (ReadTimeout, ValueError):
-            time.sleep(5 * next(fib))
+            time.sleep(delay)
+            delay = min(delay * 2, 30)
     raise TimeoutError("Waiting for space to exist took longer than expected")
 
 

--- a/trackio/imports.py
+++ b/trackio/imports.py
@@ -67,23 +67,23 @@ def import_csv(
         if c not in {step_column, "timestamp"}
     ]
 
-    col_indices = [df.columns.get_loc(c) for c in numeric_columns]
-    step_idx = df.columns.get_loc(step_column)
-    ts_idx = df.columns.get_loc("timestamp") if "timestamp" in df.columns else None
+    numeric_data = df[numeric_columns].to_numpy()
+    step_data = df[step_column].to_numpy()
+    ts_data = df["timestamp"].to_numpy() if "timestamp" in df.columns else None
 
-    for row in df.itertuples(index=False, name=None):
+    for i in range(len(df)):
         metrics = {}
-        for metric_name, idx in zip(numeric_columns, col_indices):
-            val = row[idx]
+        row_vals = numeric_data[i]
+        for metric_name, val in zip(numeric_columns, row_vals):
             if pd.notna(val):
                 metrics[metric_name] = float(val)
 
         if metrics:
             metrics_list.append(metrics)
-            steps.append(int(row[step_idx]))
+            steps.append(int(step_data[i]))
 
-            if ts_idx is not None and pd.notna(row[ts_idx]):
-                timestamps.append(str(row[ts_idx]))
+            if ts_data is not None and pd.notna(ts_data[i]):
+                timestamps.append(str(ts_data[i]))
             else:
                 timestamps.append("")
 

--- a/trackio/run.py
+++ b/trackio/run.py
@@ -9,6 +9,16 @@ from trackio.utils import RESERVED_KEYS, fibo, generate_readable_name
 
 
 class Run:
+    __slots__ = (
+        "url",
+        "project",
+        "_client_lock",
+        "_client_thread",
+        "_client",
+        "name",
+        "config",
+        "_queued_logs",
+    )
     def __init__(
         self,
         url: str,


### PR DESCRIPTION
## Summary
- optimize column simplification and name generation
- add project index caching and metrics cache
- improve update_last_steps and run caching
- simplify downsample algorithm
- revise wait_until_space_exists backoff

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb99327888328b057c603c0ee54d8